### PR TITLE
feat: Switch from initContainers to Kubernetes jobs to run db migrations

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,6 +19,6 @@ keywords:
 
 type: application
 
-version: 0.2.0
+version: 0.3.0
 
 appVersion: "1.16.0"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2017-2021 Chatwoot Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -61,83 +61,6 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{/*
-Support containers for migrations
-*/}}
-{{- define "chatwoot_helm.waitForMigrations"}}
-{{- $DATABASE_HOST :=  $.Values.env.POSTGRES_HOST }}
-{{- $REDIS_HOST :=   $.Values.env.REDIS_HOST }}
-- name: init-postgres
-  image: busybox:1.28
-  command: ["sh", "-c",  "until nslookup {{ $DATABASE_HOST }}; do echo waiting for {{ $DATABASE_HOST }}; sleep 2; done;"]
-- name: init-redis
-  image: busybox:1.28
-  command: ["sh", "-c", "until nslookup {{ $REDIS_HOST }}; do echo waiting for {{ $REDIS_HOST }}; sleep 2; done;"]
-- name: init-migrations
-  env:
-  - name: FRONTEND_URL
-    valueFrom:
-      configMapKeyRef:
-        key: FRONTEND_URL
-        name: env
-  - name: POSTGRES_HOST
-    valueFrom:
-      configMapKeyRef:
-        key: POSTGRES_HOST
-        name: env
-  - name: POSTGRES_PASSWORD
-    valueFrom:
-      configMapKeyRef:
-        key: POSTGRES_PASSWORD
-        name: env
-  - name: POSTGRES_USERNAME
-    valueFrom:
-      configMapKeyRef:
-        key: POSTGRES_USERNAME
-        name: env
-  - name: POSTGRES_PORT
-    valueFrom:
-      configMapKeyRef:
-        key: POSTGRES_PORT
-        name: env
-  - name: RAILS_ENV
-    valueFrom:
-      configMapKeyRef:
-        key: RAILS_ENV
-        name: env
-  - name: SECRET_KEY_BASE
-    valueFrom:
-      configMapKeyRef:
-        key: SECRET_KEY_BASE
-        name: env
-  - name: REDIS_PASSWORD
-    valueFrom:
-      configMapKeyRef:
-        key: REDIS_PASSWORD
-        name: env
-  - name: REDIS_SENTINEL_MASTER_NAME
-    valueFrom:
-      configMapKeyRef:
-        key: REDIS_SENTINEL_MASTER_NAME
-        name: env
-  - name: REDIS_SENTINELS
-    valueFrom:
-      configMapKeyRef:
-        key: REDIS_SENTINELS
-        name: env
-  - name: REDIS_URL
-    valueFrom:
-      configMapKeyRef:
-        key: REDIS_URL
-        name: env
-  args: 
-    - bundle
-    - exec
-    - rails
-    - db:chatwoot_prepare
-  image: "{{ .Values.deployment.image.dockerHub.chatwoot.owner }}/{{ .Values.deployment.image.dockerHub.chatwoot.repository }}:{{ .Values.deployment.image.dockerHub.chatwoot.tag }}"
-{{- end }}
-
 
 {{- define "postgres.labels" }}
 {{- include "chatwoot_helm.labels" . }}
@@ -162,10 +85,18 @@ name: {{ .Values.applicationArch.rails.name}}
 version: {{ .Values.applicationArch.rails.version}}
 {{- end }}
 
-
 {{- define "sidekiq.labels" }}
 {{- include "chatwoot_helm.labels" . }}
 component: rails
 name: {{ .Values.applicationArch.backgroundProc.name}}
 version: {{ .Values.applicationArch.backgroundProc.version}}
+{{- end }}
+
+{{- define "migration-job.labels" }}
+{{- include "chatwoot_helm.labels" . }}
+component: db-migration
+name: db-migration
+version: {{ .Values.applicationArch.rails.version}}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+release: "{{ .Release.Name }}"
 {{- end }}

--- a/templates/migrations-job.yaml
+++ b/templates/migrations-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-migrate"
+  labels:
+    {{- include "migration-job.labels" . | nindent 4}}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": {{ .Values.hooks.migrate.hookAnnotation }}
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+    "helm.sh/hook-weight": "-1"
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      initContainers:
+      - name: init-postgres
+        image: busybox:1.28
+        command: ["sh", "-c",  "until nslookup {{ .Values.env.POSTGRES_HOST }}; do echo waiting for {{ .Values.env.POSTGRES_HOST  }}; sleep 2; done;"]
+      - name: init-redis
+        image: busybox:1.28
+        command: ["sh", "-c", "until nslookup {{ .Values.env.REDIS_HOST }}; do echo waiting for {{ .Values.env.REDIS_HOST  }}; sleep 2; done;"]
+      containers:
+      - name: "db-migrate-job"
+        image: "{{ .Values.deployment.image.dockerHub.chatwoot.owner }}/{{ .Values.deployment.image.dockerHub.chatwoot.repository }}:{{ .Values.deployment.image.dockerHub.chatwoot.tag }}"
+        args:
+        - bundle
+        - exec
+        - rails
+        - db:chatwoot_prepare
+        env:
+            {{- include "chatwoot-helm.environ" .  }}
+        imagePullPolicy: {{ .Values.deployment.image.imagePullPolicy }}

--- a/templates/rails-deployment.yaml
+++ b/templates/rails-deployment.yaml
@@ -18,9 +18,6 @@ spec:
       labels:
         {{- include "rails.labels" . | nindent 8 }}
     spec:
-      initContainers:
-      {{- include "chatwoot_helm.waitForMigrations" . | nindent 6}}
-      
       containers:
         - args: 
             - bundle

--- a/templates/sidekiq-deployment.yaml
+++ b/templates/sidekiq-deployment.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         {{- include "sidekiq.labels" . | nindent 8 }}
     spec:
-      initContainers:
-      {{- include "chatwoot_helm.waitForMigrations" . | nindent 8}}
       containers:
         - args:
             - bundle

--- a/values.yaml
+++ b/values.yaml
@@ -177,6 +177,20 @@ redis:
       enabled: true
       # If change pvc size redis.master.persistence.size: 20Gi
 
+# Provide affinity for hooks if needed
+hooks:
+  affinity: {}
+  migrate:
+    env: []
+    resources:
+      limits:
+        memory: 1000Mi
+      requests:
+        memory: 1000Mi
+    # Defaults to performing the DB migration job after the install/upgrade.
+    # Can be overridden to "pre-install,pre-upgrade" with caution to perform migrations that are sometimes required for the deployment to become healthy
+    hookAnnotation: "post-install,post-upgrade"
+
 # ENVIRONMENT VARIABLES
 env:
   ACTIVE_STORAGE_SERVICE: local


### PR DESCRIPTION
## Changelog
- Switch to k8s jobs to run database-migrations
- helm lifecycle hook set to run on post-install and post-upgrade


Closes #9
Closes #5 